### PR TITLE
Relax vector type in normalize and convertion functions

### DIFF
--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -909,7 +909,7 @@ function define_bulk_rock(gv, bulk_in, bulk_in_ox, sys_in,db)
 end
 
 
-function normalize(vector::AbstractVector)
+function normalize(vector::AbstractVector{Float64})
     return vector ./ sum(vector)
 end
 

--- a/julia/MAGEMin_wrappers.jl
+++ b/julia/MAGEMin_wrappers.jl
@@ -909,7 +909,7 @@ function define_bulk_rock(gv, bulk_in, bulk_in_ox, sys_in,db)
 end
 
 
-function normalize(vector::Vector{Float64})
+function normalize(vector::AbstractVector)
     return vector ./ sum(vector)
 end
 
@@ -917,8 +917,8 @@ end
     bulk_mol = wt2mol(bulk_wt, bulk_ox)
 Converts bulk-rock composition from wt to mol fraction
 """
-function wt2mol(    bulk_wt     :: Vector{Float64},
-                    bulk_ox     :: Vector{String}) 
+function wt2mol(    bulk_wt     :: AbstractVector{Float64},
+                    bulk_ox     :: AbstractVector{String}) 
 
     ref_ox          = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "O"; "Cr2O3"; "MnO"; "H2O"; "CO2"; "S"];
     ref_MolarMass   = [60.08; 101.96; 56.08; 40.30; 71.85; 159.69; 94.2; 61.98; 79.88; 16.0; 151.99; 70.937; 18.015; 44.01; 32.06];      #Molar mass of oxides
@@ -926,7 +926,7 @@ function wt2mol(    bulk_wt     :: Vector{Float64},
     bulk_mol = zeros(length(bulk_ox));
     bulk_wt  = normalize(bulk_wt)
 
-    for i = 1:length(bulk_ox)
+    for i = axes(bulk_ox,1)
         id = findfirst(ref_ox .== bulk_ox[i]);
         bulk_mol[i] = bulk_wt[i]/ref_MolarMass[id];
     end
@@ -942,8 +942,8 @@ end
 
     Converts bulk-rock composition from mol to wt fraction
 """
-function mol2wt(    bulk_mol     :: Vector{Float64},
-                    bulk_ox      :: Vector{String}) 
+function mol2wt(    bulk_mol     :: AbstractVector{Float64},
+                    bulk_ox      :: AbstractVector{String}) 
 
     ref_ox          = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "O"; "Cr2O3"; "MnO"; "H2O"; "CO2"; "S"];
     ref_MolarMass   = [60.08; 101.96; 56.08; 40.30; 71.85; 159.69; 94.2; 61.98; 79.88; 16.0; 151.99; 70.937; 18.015; 44.01; 32.06];      #Molar mass of oxides
@@ -951,7 +951,7 @@ function mol2wt(    bulk_mol     :: Vector{Float64},
     bulk_wt = zeros(length(bulk_ox));
     bulk_mol = normalize(bulk_mol)
 
-    for i = 1:length(bulk_ox)
+    for i = axes(bulk_ox,1)
         id = findfirst(ref_ox .== bulk_ox[i]);
         bulk_wt[i] = bulk_mol[i]*ref_MolarMass[id];
     end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -430,11 +430,21 @@ end
     Xoxides = ["SiO2"; "Al2O3"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"];
     X1      = [48.43; 15.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
     X2      = [49.43; 14.19; 11.57; 10.13; 6.65; 1.64; 0.59; 1.87; 0.68; 0.0; 3.0];
-    X       = [X1,X2]
+    X       = [X1, X2] # only use first two points
     sys_in  = "wt"
-    P_view = @view P[1:2]
-    T_view = @view T[1:2]
+    P_view  = @view P[1:2]
+    T_view  = @view T[1:2]
     out     = multi_point_minimization(P_view, T_view, data, X=X, Xoxides=Xoxides, sys_in=sys_in)
+
+    # test with a view of the bulk rock
+    index_shufle   = [2,1,3,4,5,6,7,8,9,10,11]
+    Xoxides_shufle = ["Al2O3"; "SiO2"; "CaO"; "MgO"; "FeO"; "Fe2O3"; "K2O"; "Na2O"; "TiO2"; "Cr2O3"; "H2O"]
+    X1_view        = @view X1[index_shufle]
+
+    # just run it to be sure it is not erroring
+    out     = single_point_minimization(P[3], T[3], data, X=X1_view, Xoxides=Xoxides_shufle, sys_in=sys_in)
+    mol2wt(X1_view, Xoxides_shufle) # convert to mol
+    wt2mol(X1_view, Xoxides_shufle) # convert to mol
 
     Finalize_MAGEMin(data)
 end


### PR DESCRIPTION
Trying to make some old code working with the current version of MAGEMin!

Just a small change to allow the use of other types of vectors for 3 functions that were erroring. 

I've added a test to make sure it will keep working in the future.

If that is fine, and I can also do the changes on the other repo.